### PR TITLE
Fixes sleep when timer is 0

### DIFF
--- a/src/keymon/keymon.c
+++ b/src/keymon/keymon.c
@@ -562,6 +562,9 @@ int main(void)
                             if (settings.disable_standby) {
                                 deepsleep();
                             }
+                            else if (settings.sleep_timer == 0) {
+                                suspend_exec(SHUTDOWN_MIN * 60000);
+                            }
                             else {
                                 turnOffScreen();
                             }


### PR DESCRIPTION
Fixes https://github.com/OnionUI/Onion/issues/1851 - This fix checks if the Sleep_Timer is 0, if it is then sleeps the device when the power button is pressed.

After a while with the screen turned off it will shutdown the device as it does when a value is set.